### PR TITLE
removed completed status filter

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 8192:
+/***/ 6946:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28,7 +28,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
 const os = __importStar(__nccwpck_require__(2037));
-const utils_1 = __nccwpck_require__(6947);
+const utils_1 = __nccwpck_require__(918);
 /**
  * Commands
  *
@@ -100,7 +100,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 4740:
+/***/ 6150:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -135,12 +135,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(8192);
-const file_command_1 = __nccwpck_require__(3921);
-const utils_1 = __nccwpck_require__(6947);
+const command_1 = __nccwpck_require__(6946);
+const file_command_1 = __nccwpck_require__(1589);
+const utils_1 = __nccwpck_require__(918);
 const os = __importStar(__nccwpck_require__(2037));
 const path = __importStar(__nccwpck_require__(1017));
-const oidc_utils_1 = __nccwpck_require__(6166);
+const oidc_utils_1 = __nccwpck_require__(1238);
 /**
  * The code to exit an action
  */
@@ -425,17 +425,17 @@ exports.getIDToken = getIDToken;
 /**
  * Summary exports
  */
-var summary_1 = __nccwpck_require__(9296);
+var summary_1 = __nccwpck_require__(5999);
 Object.defineProperty(exports, "summary", ({ enumerable: true, get: function () { return summary_1.summary; } }));
 /**
  * @deprecated use core.summary
  */
-var summary_2 = __nccwpck_require__(9296);
+var summary_2 = __nccwpck_require__(5999);
 Object.defineProperty(exports, "markdownSummary", ({ enumerable: true, get: function () { return summary_2.markdownSummary; } }));
 /**
  * Path exports
  */
-var path_utils_1 = __nccwpck_require__(8342);
+var path_utils_1 = __nccwpck_require__(1039);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
@@ -443,7 +443,7 @@ Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: funct
 
 /***/ }),
 
-/***/ 3921:
+/***/ 1589:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -474,8 +474,8 @@ exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(7147));
 const os = __importStar(__nccwpck_require__(2037));
-const uuid_1 = __nccwpck_require__(446);
-const utils_1 = __nccwpck_require__(6947);
+const uuid_1 = __nccwpck_require__(4573);
+const utils_1 = __nccwpck_require__(918);
 function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -508,7 +508,7 @@ exports.prepareKeyValueMessage = prepareKeyValueMessage;
 
 /***/ }),
 
-/***/ 6166:
+/***/ 1238:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -524,9 +524,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
-const http_client_1 = __nccwpck_require__(655);
-const auth_1 = __nccwpck_require__(4309);
-const core_1 = __nccwpck_require__(4740);
+const http_client_1 = __nccwpck_require__(5578);
+const auth_1 = __nccwpck_require__(8436);
+const core_1 = __nccwpck_require__(6150);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -592,7 +592,7 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 8342:
+/***/ 1039:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -657,7 +657,7 @@ exports.toPlatformPath = toPlatformPath;
 
 /***/ }),
 
-/***/ 9296:
+/***/ 5999:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -947,7 +947,7 @@ exports.summary = _summary;
 
 /***/ }),
 
-/***/ 6947:
+/***/ 918:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -994,7 +994,7 @@ exports.toCommandProperties = toCommandProperties;
 
 /***/ }),
 
-/***/ 507:
+/***/ 4414:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1055,7 +1055,7 @@ exports.Context = Context;
 
 /***/ }),
 
-/***/ 8478:
+/***/ 6557:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1081,8 +1081,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOctokit = exports.context = void 0;
-const Context = __importStar(__nccwpck_require__(507));
-const utils_1 = __nccwpck_require__(7415);
+const Context = __importStar(__nccwpck_require__(4414));
+const utils_1 = __nccwpck_require__(402);
 exports.context = new Context.Context();
 /**
  * Returns a hydrated octokit ready to use for GitHub Actions
@@ -1099,7 +1099,7 @@ exports.getOctokit = getOctokit;
 
 /***/ }),
 
-/***/ 9410:
+/***/ 9097:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1125,7 +1125,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getApiBaseUrl = exports.getProxyAgent = exports.getAuthString = void 0;
-const httpClient = __importStar(__nccwpck_require__(655));
+const httpClient = __importStar(__nccwpck_require__(5578));
 function getAuthString(token, options) {
     if (!token && !options.auth) {
         throw new Error('Parameter token or opts.auth is required');
@@ -1149,7 +1149,7 @@ exports.getApiBaseUrl = getApiBaseUrl;
 
 /***/ }),
 
-/***/ 7415:
+/***/ 402:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1175,12 +1175,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOctokitOptions = exports.GitHub = exports.defaults = exports.context = void 0;
-const Context = __importStar(__nccwpck_require__(507));
-const Utils = __importStar(__nccwpck_require__(9410));
+const Context = __importStar(__nccwpck_require__(4414));
+const Utils = __importStar(__nccwpck_require__(9097));
 // octokit + plugins
-const core_1 = __nccwpck_require__(9591);
-const plugin_rest_endpoint_methods_1 = __nccwpck_require__(4014);
-const plugin_paginate_rest_1 = __nccwpck_require__(5);
+const core_1 = __nccwpck_require__(3293);
+const plugin_rest_endpoint_methods_1 = __nccwpck_require__(9683);
+const plugin_paginate_rest_1 = __nccwpck_require__(357);
 exports.context = new Context.Context();
 const baseUrl = Utils.getApiBaseUrl();
 exports.defaults = {
@@ -1210,7 +1210,7 @@ exports.getOctokitOptions = getOctokitOptions;
 
 /***/ }),
 
-/***/ 4309:
+/***/ 8436:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -1298,7 +1298,7 @@ exports.PersonalAccessTokenCredentialHandler = PersonalAccessTokenCredentialHand
 
 /***/ }),
 
-/***/ 655:
+/***/ 5578:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1336,8 +1336,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpClient = exports.isHttps = exports.HttpClientResponse = exports.HttpClientError = exports.getProxyUrl = exports.MediaTypes = exports.Headers = exports.HttpCodes = void 0;
 const http = __importStar(__nccwpck_require__(3685));
 const https = __importStar(__nccwpck_require__(5687));
-const pm = __importStar(__nccwpck_require__(2934));
-const tunnel = __importStar(__nccwpck_require__(4312));
+const pm = __importStar(__nccwpck_require__(7390));
+const tunnel = __importStar(__nccwpck_require__(3382));
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -1923,7 +1923,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 
 /***/ }),
 
-/***/ 2934:
+/***/ 7390:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2012,7 +2012,7 @@ function isLoopbackAddress(host) {
 
 /***/ }),
 
-/***/ 6299:
+/***/ 9548:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2075,7 +2075,7 @@ exports.createTokenAuth = createTokenAuth;
 
 /***/ }),
 
-/***/ 9591:
+/***/ 3293:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2083,11 +2083,11 @@ exports.createTokenAuth = createTokenAuth;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var universalUserAgent = __nccwpck_require__(4300);
-var beforeAfterHook = __nccwpck_require__(6330);
-var request = __nccwpck_require__(7237);
-var graphql = __nccwpck_require__(6963);
-var authToken = __nccwpck_require__(6299);
+var universalUserAgent = __nccwpck_require__(8772);
+var beforeAfterHook = __nccwpck_require__(3721);
+var request = __nccwpck_require__(7263);
+var graphql = __nccwpck_require__(8619);
+var authToken = __nccwpck_require__(9548);
 
 function _objectWithoutPropertiesLoose(source, excluded) {
   if (source == null) return {};
@@ -2259,7 +2259,7 @@ exports.Octokit = Octokit;
 
 /***/ }),
 
-/***/ 2991:
+/***/ 8405:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2267,8 +2267,8 @@ exports.Octokit = Octokit;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var isPlainObject = __nccwpck_require__(9524);
-var universalUserAgent = __nccwpck_require__(4300);
+var isPlainObject = __nccwpck_require__(277);
+var universalUserAgent = __nccwpck_require__(8772);
 
 function lowercaseKeys(object) {
   if (!object) {
@@ -2657,7 +2657,7 @@ exports.endpoint = endpoint;
 
 /***/ }),
 
-/***/ 6963:
+/***/ 8619:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2665,8 +2665,8 @@ exports.endpoint = endpoint;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var request = __nccwpck_require__(7237);
-var universalUserAgent = __nccwpck_require__(4300);
+var request = __nccwpck_require__(7263);
+var universalUserAgent = __nccwpck_require__(8772);
 
 const VERSION = "4.8.0";
 
@@ -2783,7 +2783,7 @@ exports.withCustomRequest = withCustomRequest;
 
 /***/ }),
 
-/***/ 5:
+/***/ 357:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2996,7 +2996,7 @@ exports.paginatingEndpoints = paginatingEndpoints;
 
 /***/ }),
 
-/***/ 4014:
+/***/ 9683:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4111,7 +4111,7 @@ exports.restEndpointMethods = restEndpointMethods;
 
 /***/ }),
 
-/***/ 8757:
+/***/ 827:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4121,8 +4121,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var deprecation = __nccwpck_require__(8999);
-var once = _interopDefault(__nccwpck_require__(575));
+var deprecation = __nccwpck_require__(4282);
+var once = _interopDefault(__nccwpck_require__(1801));
 
 const logOnceCode = once(deprecation => console.warn(deprecation));
 const logOnceHeaders = once(deprecation => console.warn(deprecation));
@@ -4193,7 +4193,7 @@ exports.RequestError = RequestError;
 
 /***/ }),
 
-/***/ 7237:
+/***/ 7263:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4203,11 +4203,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var endpoint = __nccwpck_require__(2991);
-var universalUserAgent = __nccwpck_require__(4300);
-var isPlainObject = __nccwpck_require__(9524);
-var nodeFetch = _interopDefault(__nccwpck_require__(7817));
-var requestError = __nccwpck_require__(8757);
+var endpoint = __nccwpck_require__(8405);
+var universalUserAgent = __nccwpck_require__(8772);
+var isPlainObject = __nccwpck_require__(277);
+var nodeFetch = _interopDefault(__nccwpck_require__(6818));
+var requestError = __nccwpck_require__(827);
 
 const VERSION = "5.6.3";
 
@@ -4378,12 +4378,12 @@ exports.request = request;
 
 /***/ }),
 
-/***/ 6330:
+/***/ 3721:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var register = __nccwpck_require__(1104);
-var addHook = __nccwpck_require__(1884);
-var removeHook = __nccwpck_require__(1040);
+var register = __nccwpck_require__(5737);
+var addHook = __nccwpck_require__(9478);
+var removeHook = __nccwpck_require__(2549);
 
 // bind with array of arguments: https://stackoverflow.com/a/21792913
 var bind = Function.bind;
@@ -4446,7 +4446,7 @@ module.exports.Collection = Hook.Collection;
 
 /***/ }),
 
-/***/ 1884:
+/***/ 9478:
 /***/ ((module) => {
 
 module.exports = addHook;
@@ -4499,7 +4499,7 @@ function addHook(state, kind, name, hook) {
 
 /***/ }),
 
-/***/ 1104:
+/***/ 5737:
 /***/ ((module) => {
 
 module.exports = register;
@@ -4533,7 +4533,7 @@ function register(state, name, method, options) {
 
 /***/ }),
 
-/***/ 1040:
+/***/ 2549:
 /***/ ((module) => {
 
 module.exports = removeHook;
@@ -4559,7 +4559,7 @@ function removeHook(state, name, method) {
 
 /***/ }),
 
-/***/ 8999:
+/***/ 4282:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4587,7 +4587,7 @@ exports.Deprecation = Deprecation;
 
 /***/ }),
 
-/***/ 9524:
+/***/ 277:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4633,7 +4633,7 @@ exports.isPlainObject = isPlainObject;
 
 /***/ }),
 
-/***/ 7817:
+/***/ 6818:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4646,7 +4646,7 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 var Stream = _interopDefault(__nccwpck_require__(2781));
 var http = _interopDefault(__nccwpck_require__(3685));
 var Url = _interopDefault(__nccwpck_require__(7310));
-var whatwgUrl = _interopDefault(__nccwpck_require__(721));
+var whatwgUrl = _interopDefault(__nccwpck_require__(4396));
 var https = _interopDefault(__nccwpck_require__(5687));
 var zlib = _interopDefault(__nccwpck_require__(9796));
 
@@ -4799,7 +4799,7 @@ FetchError.prototype.name = 'FetchError';
 
 let convert;
 try {
-	convert = (__nccwpck_require__(1665).convert);
+	convert = (__nccwpck_require__(3446).convert);
 } catch (e) {}
 
 const INTERNALS = Symbol('Body internals');
@@ -6428,10 +6428,10 @@ exports.AbortError = AbortError;
 
 /***/ }),
 
-/***/ 575:
+/***/ 1801:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var wrappy = __nccwpck_require__(8569)
+var wrappy = __nccwpck_require__(4541)
 module.exports = wrappy(once)
 module.exports.strict = wrappy(onceStrict)
 
@@ -6477,7 +6477,7 @@ function onceStrict (fn) {
 
 /***/ }),
 
-/***/ 9521:
+/***/ 5664:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -6678,15 +6678,15 @@ module.exports.PROCESSING_OPTIONS = PROCESSING_OPTIONS;
 
 /***/ }),
 
-/***/ 4312:
+/***/ 3382:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(1355);
+module.exports = __nccwpck_require__(5695);
 
 
 /***/ }),
 
-/***/ 1355:
+/***/ 5695:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -6958,7 +6958,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 4300:
+/***/ 8772:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -6984,7 +6984,7 @@ exports.getUserAgent = getUserAgent;
 
 /***/ }),
 
-/***/ 446:
+/***/ 4573:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7048,29 +7048,29 @@ Object.defineProperty(exports, "parse", ({
   }
 }));
 
-var _v = _interopRequireDefault(__nccwpck_require__(1527));
+var _v = _interopRequireDefault(__nccwpck_require__(1592));
 
-var _v2 = _interopRequireDefault(__nccwpck_require__(3489));
+var _v2 = _interopRequireDefault(__nccwpck_require__(6927));
 
-var _v3 = _interopRequireDefault(__nccwpck_require__(4217));
+var _v3 = _interopRequireDefault(__nccwpck_require__(7560));
 
-var _v4 = _interopRequireDefault(__nccwpck_require__(8529));
+var _v4 = _interopRequireDefault(__nccwpck_require__(8550));
 
-var _nil = _interopRequireDefault(__nccwpck_require__(5868));
+var _nil = _interopRequireDefault(__nccwpck_require__(2880));
 
-var _version = _interopRequireDefault(__nccwpck_require__(3197));
+var _version = _interopRequireDefault(__nccwpck_require__(2146));
 
-var _validate = _interopRequireDefault(__nccwpck_require__(206));
+var _validate = _interopRequireDefault(__nccwpck_require__(5744));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(7194));
+var _stringify = _interopRequireDefault(__nccwpck_require__(2746));
 
-var _parse = _interopRequireDefault(__nccwpck_require__(8596));
+var _parse = _interopRequireDefault(__nccwpck_require__(2139));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /***/ }),
 
-/***/ 1332:
+/***/ 390:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7100,7 +7100,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 5868:
+/***/ 2880:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -7115,7 +7115,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 8596:
+/***/ 2139:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7126,7 +7126,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(206));
+var _validate = _interopRequireDefault(__nccwpck_require__(5744));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7167,7 +7167,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 1110:
+/***/ 2789:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -7182,7 +7182,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 9460:
+/***/ 2507:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7213,7 +7213,7 @@ function rng() {
 
 /***/ }),
 
-/***/ 8844:
+/***/ 696:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7243,7 +7243,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 7194:
+/***/ 2746:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7254,7 +7254,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(206));
+var _validate = _interopRequireDefault(__nccwpck_require__(5744));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7289,7 +7289,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 1527:
+/***/ 1592:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7300,9 +7300,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _rng = _interopRequireDefault(__nccwpck_require__(9460));
+var _rng = _interopRequireDefault(__nccwpck_require__(2507));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(7194));
+var _stringify = _interopRequireDefault(__nccwpck_require__(2746));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7403,7 +7403,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 3489:
+/***/ 6927:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7414,9 +7414,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _v = _interopRequireDefault(__nccwpck_require__(7259));
+var _v = _interopRequireDefault(__nccwpck_require__(5792));
 
-var _md = _interopRequireDefault(__nccwpck_require__(1332));
+var _md = _interopRequireDefault(__nccwpck_require__(390));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7426,7 +7426,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 7259:
+/***/ 5792:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7438,9 +7438,9 @@ Object.defineProperty(exports, "__esModule", ({
 exports["default"] = _default;
 exports.URL = exports.DNS = void 0;
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(7194));
+var _stringify = _interopRequireDefault(__nccwpck_require__(2746));
 
-var _parse = _interopRequireDefault(__nccwpck_require__(8596));
+var _parse = _interopRequireDefault(__nccwpck_require__(2139));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7511,7 +7511,7 @@ function _default(name, version, hashfunc) {
 
 /***/ }),
 
-/***/ 4217:
+/***/ 7560:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7522,9 +7522,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _rng = _interopRequireDefault(__nccwpck_require__(9460));
+var _rng = _interopRequireDefault(__nccwpck_require__(2507));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(7194));
+var _stringify = _interopRequireDefault(__nccwpck_require__(2746));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7555,7 +7555,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 8529:
+/***/ 8550:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7566,9 +7566,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _v = _interopRequireDefault(__nccwpck_require__(7259));
+var _v = _interopRequireDefault(__nccwpck_require__(5792));
 
-var _sha = _interopRequireDefault(__nccwpck_require__(8844));
+var _sha = _interopRequireDefault(__nccwpck_require__(696));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7578,7 +7578,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 206:
+/***/ 5744:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7589,7 +7589,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _regex = _interopRequireDefault(__nccwpck_require__(1110));
+var _regex = _interopRequireDefault(__nccwpck_require__(2789));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7602,7 +7602,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 3197:
+/***/ 2146:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7613,7 +7613,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(206));
+var _validate = _interopRequireDefault(__nccwpck_require__(5744));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7630,7 +7630,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 9666:
+/***/ 3844:
 /***/ ((module) => {
 
 "use strict";
@@ -7827,12 +7827,12 @@ conversions["RegExp"] = function (V, opts) {
 
 /***/ }),
 
-/***/ 4136:
+/***/ 3375:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-const usm = __nccwpck_require__(691);
+const usm = __nccwpck_require__(5847);
 
 exports.implementation = class URLImpl {
   constructor(constructorArgs) {
@@ -8035,15 +8035,15 @@ exports.implementation = class URLImpl {
 
 /***/ }),
 
-/***/ 5063:
+/***/ 6003:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const conversions = __nccwpck_require__(9666);
-const utils = __nccwpck_require__(1417);
-const Impl = __nccwpck_require__(4136);
+const conversions = __nccwpck_require__(3844);
+const utils = __nccwpck_require__(5509);
+const Impl = __nccwpck_require__(3375);
 
 const impl = utils.implSymbol;
 
@@ -8239,32 +8239,32 @@ module.exports = {
 
 /***/ }),
 
-/***/ 721:
+/***/ 4396:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-exports.URL = __nccwpck_require__(5063)["interface"];
-exports.serializeURL = __nccwpck_require__(691).serializeURL;
-exports.serializeURLOrigin = __nccwpck_require__(691).serializeURLOrigin;
-exports.basicURLParse = __nccwpck_require__(691).basicURLParse;
-exports.setTheUsername = __nccwpck_require__(691).setTheUsername;
-exports.setThePassword = __nccwpck_require__(691).setThePassword;
-exports.serializeHost = __nccwpck_require__(691).serializeHost;
-exports.serializeInteger = __nccwpck_require__(691).serializeInteger;
-exports.parseURL = __nccwpck_require__(691).parseURL;
+exports.URL = __nccwpck_require__(6003)["interface"];
+exports.serializeURL = __nccwpck_require__(5847).serializeURL;
+exports.serializeURLOrigin = __nccwpck_require__(5847).serializeURLOrigin;
+exports.basicURLParse = __nccwpck_require__(5847).basicURLParse;
+exports.setTheUsername = __nccwpck_require__(5847).setTheUsername;
+exports.setThePassword = __nccwpck_require__(5847).setThePassword;
+exports.serializeHost = __nccwpck_require__(5847).serializeHost;
+exports.serializeInteger = __nccwpck_require__(5847).serializeInteger;
+exports.parseURL = __nccwpck_require__(5847).parseURL;
 
 
 /***/ }),
 
-/***/ 691:
+/***/ 5847:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const punycode = __nccwpck_require__(5477);
-const tr46 = __nccwpck_require__(9521);
+const tr46 = __nccwpck_require__(5664);
 
 const specialSchemes = {
   ftp: 21,
@@ -9563,7 +9563,7 @@ module.exports.parseURL = function (input, options) {
 
 /***/ }),
 
-/***/ 1417:
+/***/ 5509:
 /***/ ((module) => {
 
 "use strict";
@@ -9591,7 +9591,7 @@ module.exports.implForWrapper = function (wrapper) {
 
 /***/ }),
 
-/***/ 8569:
+/***/ 4541:
 /***/ ((module) => {
 
 // Returns a wrapper function that returns a wrapped callback
@@ -9631,7 +9631,7 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
-/***/ 9689:
+/***/ 5514:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -9669,8 +9669,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__nccwpck_require__(4740));
-const github = __importStar(__nccwpck_require__(8478));
+const core = __importStar(__nccwpck_require__(6150));
+const github = __importStar(__nccwpck_require__(6557));
 function ghEnv(key) {
     return process.env[key];
 }
@@ -9720,9 +9720,6 @@ function handleJobSha({ octokit, owner, repo, currentBranchName, jobName, }) {
             .listWorkflowRunsForRepo({
             owner,
             repo,
-            // using completed because we don't care about the status of the workflow, fail, or success, as long as it's completed
-            // we just want a job that was successful
-            status: "completed",
             branch: currentBranchName,
         })
             .catch((e) => {
@@ -9807,7 +9804,7 @@ main();
 
 /***/ }),
 
-/***/ 1665:
+/***/ 3446:
 /***/ ((module) => {
 
 module.exports = eval("require")("encoding");
@@ -9985,7 +9982,7 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(9689);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(5514);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "latest-successful-job-run",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "main": "src/index.ts",
   "scripts": {},

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: My successful job
         id: successful_job
-        uses: khongchai/latest-successful-job-run@v2
+        uses: khongchai/latest-successful-job-run@v2.1.0
         with:
           # `job` must be provided
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: My successful job
         id: successful_job
-        uses: khongchai/latest-successful-job-run@v2
+        uses: khongchai/latest-successful-job-run@v2.1.0
         with:
           # provide just the token
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,9 +85,6 @@ async function handleJobSha({
     .listWorkflowRunsForRepo({
       owner,
       repo,
-      // using completed because we don't care about the status of the workflow, fail, or success, as long as it's completed
-      // we just want a job that was successful
-      status: "completed",
       branch: currentBranchName,
     })
     .catch((e) => {


### PR DESCRIPTION
Remove the "completed" status filter when looking for the most recent successful job, in order to retrieve the commit from a successful job even if the entire workflow is still in progress.